### PR TITLE
Add csv-sample command with reservoir sampling

### DIFF
--- a/exe/csv-sample
+++ b/exe/csv-sample
@@ -1,0 +1,56 @@
+#!/usr/bin/env ruby
+
+require 'csv'
+require 'optparse'
+require_relative '../lib/csvutil'
+
+CMD = File.basename __FILE__
+
+def print_version
+  puts "#{CMD} #{CSVUtil::VERSION}"
+  exit
+end
+
+options = {}
+OptionParser.new do |opts|
+  opts.banner = <<~EOF
+    Usage: #{CMD} [options] CSV
+
+    Output a random sample of rows from the CSV.
+
+    NB: Assumes CSV has headers.
+
+  EOF
+
+  opts.on '-v', '--version', "Print #{CMD} and quit" do
+    print_version
+  end
+
+  opts.on '-n', '--count N', Integer, "Number of rows to sample (default: 1)" do |n|
+    options[:count] = n
+  end
+
+  opts.on '--seed N', Integer, "Random seed for reproducible output" do |n|
+    options[:seed] = n
+  end
+
+  opts.on '-o', '--outfile OUTFILE', "Output filename (default: stdout)" do |outfile|
+    options[:outfile] = outfile
+  end
+
+  opts.on '-h', '--help', "Print this help\n\n" do
+    puts opts
+    exit
+  end
+end.parse!
+
+if ARGV.any? || $stdin.tty?
+  csv_file = ARGV.shift
+  abort "Please provide a CSV file" unless csv_file
+  abort "Can't find CSV file" unless File.exist? csv_file
+  input = File.open csv_file
+else
+  input = $stdin
+end
+
+CSVUtil::Sample.new(input, **options).process

--- a/lib/csv_util/sample.rb
+++ b/lib/csv_util/sample.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module CSVUtil
+  class Sample < Command
+    attr_reader :input, :count, :seed
+
+    def initialize input, options = {}
+      @input = input
+      @count = options[:count] || 1
+      @seed  = options[:seed]
+      super options
+    end
+
+    def process
+      srand(seed) if seed
+
+      reservoir = []
+      headers   = nil
+      i         = 0
+
+      read(input) do |row|
+        headers ||= row.headers
+        if i < count
+          reservoir << row
+        else
+          j = rand(i + 1)
+          reservoir[j] = row if j < count
+        end
+        i += 1
+      end
+
+      write do |csv|
+        csv << headers
+        reservoir.each { |row| csv << row }
+      end
+    end
+  end
+end

--- a/lib/csvutil.rb
+++ b/lib/csvutil.rb
@@ -11,6 +11,7 @@ require_relative 'csv_util/cat'
 require_relative 'csv_util/cut'
 require_relative 'csv_util/filter'
 require_relative 'csv_util/split'
+require_relative 'csv_util/sample'
 require_relative 'csv_util/slice'
 
 module CSVUtil

--- a/spec/csv_util/sample_spec.rb
+++ b/spec/csv_util/sample_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe CSVUtil::Sample do
+  let(:csv) {
+    <<~CSV
+      first_col,second_col,third_col
+      easel,floor,girder
+      egg,fig,grape
+      elbow,foot,gut
+      eager,fickle,giddy
+      steak,fig,cheese
+      cucumber,fig,omelet
+    CSV
+  }
+
+  let(:csv_file) {
+    sio = StringIO.new
+    sio.write csv
+    sio.rewind
+    sio
+  }
+
+  let(:options) { {} }
+  let(:subject) { CSVUtil::Sample.new csv_file, **options }
+
+  def capture_stdout
+    io = StringIO.new
+    orig, $stdout = $stdout, io
+    yield
+    io.string
+  ensure
+    $stdout = orig
+  end
+
+  def data_rows(output)
+    output.strip.split("\n").length - 1
+  end
+
+  context '#process' do
+    it 'outputs the header row' do
+      output = capture_stdout { subject.process }
+      expect(output.lines.first.chomp).to eq 'first_col,second_col,third_col'
+    end
+
+    it 'outputs 1 data row by default' do
+      output = capture_stdout { subject.process }
+      expect(data_rows(output)).to eq 1
+    end
+
+    context 'with count: 3' do
+      let(:options) { { count: 3 } }
+
+      it 'outputs 3 data rows' do
+        output = capture_stdout { subject.process }
+        expect(data_rows(output)).to eq 3
+      end
+    end
+
+    context 'with seed' do
+      let(:options) { { seed: 42 } }
+
+      it 'produces the same output on repeated runs' do
+        sio2 = StringIO.new; sio2.write csv; sio2.rewind
+        out1 = capture_stdout { subject.process }
+        out2 = capture_stdout { CSVUtil::Sample.new(sio2, seed: 42).process }
+        expect(out1).to eq out2
+      end
+    end
+
+    context 'when count exceeds row count' do
+      let(:options) { { count: 100 } }
+
+      it 'outputs all rows' do
+        output = capture_stdout { subject.process }
+        expect(data_rows(output)).to eq 6
+      end
+    end
+  end
+end

--- a/tests/test-csv-sample.sh
+++ b/tests/test-csv-sample.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+input_csv='first_col,second_col,third_col
+easel,floor,girder
+egg,fig,grape
+elbow,foot,gut
+eager,fickle,giddy
+steak,fig,cheese
+cucumber,fig,omelet'
+
+test_sample_default_is_one_row() {
+  actual=$(echo "${input_csv}" | ${CSV_SAMPLE})
+  rows=$(echo "${actual}" | wc -l)
+  assert_equals 2 ${rows} 'Unexpected number of rows (header + 1 data row)'
+}
+
+test_sample_count() {
+  actual=$(echo "${input_csv}" | ${CSV_SAMPLE} --count 3)
+  rows=$(echo "${actual}" | wc -l)
+  assert_equals 4 ${rows} 'Unexpected number of rows (header + 3 data rows)'
+}
+
+test_sample_includes_header() {
+  actual=$(echo "${input_csv}" | ${CSV_SAMPLE} --count 2)
+  header=$(echo "${actual}" | head -1)
+  assert_equals 'first_col,second_col,third_col' "${header}" 'Missing or wrong header'
+}
+
+test_sample_seed_is_reproducible() {
+  out1=$(echo "${input_csv}" | ${CSV_SAMPLE} --count 2 --seed 42)
+  out2=$(echo "${input_csv}" | ${CSV_SAMPLE} --count 2 --seed 42)
+  assert_equals "${out1}" "${out2}" 'Seeded runs produced different output'
+}
+
+test_pipe_to_csv_sample() {
+  actual=$(echo "${input_csv}" | ${CSV_SAMPLE} --count 2)
+  rows=$(echo "${actual}" | wc -l)
+  assert_equals 3 ${rows} 'Unexpected number of rows'
+}
+
+CSV_SAMPLE="eval ../exe/csv-sample"


### PR DESCRIPTION
Implements Algorithm R for uniform random row sampling without loading the full file into memory. Supports --count N (default 1) and --seed N for reproducible output.